### PR TITLE
Pass state_digest and nonce as symbols instead of as string keys

### DIFF
--- a/lib/omniauth/login_dot_gov/callback.rb
+++ b/lib/omniauth/login_dot_gov/callback.rb
@@ -47,7 +47,7 @@ module OmniAuth
       end
 
       def get_oidc_value_from_session(key)
-        oidc_session = session['oidc']
+        oidc_session = session[:oidc]
         return if oidc_session.nil?
         oidc_session[key]
       end

--- a/lib/omniauth/login_dot_gov/callback.rb
+++ b/lib/omniauth/login_dot_gov/callback.rb
@@ -29,7 +29,7 @@ module OmniAuth
         cb_state_digest = OpenSSL::Digest::SHA256.base64digest(cb_state)
         return if SecureCompare.compare(
           cb_state_digest,
-          get_oidc_value_from_session('state_digest')
+          get_oidc_value_from_session(:state_digest)
         )
         raise CallbackStateMismatchError
       end

--- a/lib/omniauth/login_dot_gov/callback.rb
+++ b/lib/omniauth/login_dot_gov/callback.rb
@@ -15,7 +15,7 @@ module OmniAuth
           code: params['code'],
           client: client
         ).request_id_token
-        id_token.verify_nonce(get_oidc_value_from_session('nonce_digest'))
+        id_token.verify_nonce(get_oidc_value_from_session(:nonce_digest))
         @userinfo = UserinfoRequest.new(
           id_token: id_token,
           client: client

--- a/spec/omniauth/login_dot_gov/callback_spec.rb
+++ b/spec/omniauth/login_dot_gov/callback_spec.rb
@@ -22,7 +22,7 @@ describe OmniAuth::LoginDotGov::Callback do
   let(:nonce_digest) { OpenSSL::Digest::SHA256.base64digest(nonce) }
   let(:session) do
     {
-      'oidc' => {
+      oidc: {
         state_digest: state_digest,
         nonce_digest: nonce_digest,
       }

--- a/spec/omniauth/login_dot_gov/callback_spec.rb
+++ b/spec/omniauth/login_dot_gov/callback_spec.rb
@@ -23,9 +23,9 @@ describe OmniAuth::LoginDotGov::Callback do
   let(:session) do
     {
       'oidc' => {
-        'state_digest' => state_digest,
-        'nonce_digest' => nonce_digest,
-      },
+        state_digest: state_digest,
+        nonce_digest: nonce_digest,
+      }
     }
   end
 


### PR DESCRIPTION
This bug fix will correct the OmniAuth::LoginDotGov::CallbackStateMismatchError.