### PR TITLE
Normalizes session object for consistency

### DIFF
--- a/lib/omniauth/login_dot_gov/callback.rb
+++ b/lib/omniauth/login_dot_gov/callback.rb
@@ -4,7 +4,7 @@ module OmniAuth
       attr_reader :session, :client, :id_token, :userinfo
 
       def initialize(session:, client:)
-        @session = session
+        @session = session.to_hash.symbolize_keys
         @client = client
       end
 
@@ -47,7 +47,7 @@ module OmniAuth
       end
 
       def get_oidc_value_from_session(key)
-        oidc_session = session[:oidc]
+        oidc_session = session[:oidc].symbolize_keys
         return if oidc_session.nil?
         oidc_session[key]
       end

--- a/spec/omniauth/login_dot_gov/callback_spec.rb
+++ b/spec/omniauth/login_dot_gov/callback_spec.rb
@@ -115,5 +115,57 @@ describe OmniAuth::LoginDotGov::Callback do
         )
       end
     end
+
+    context 'when serialization of session differs' do
+      context 'when object keys are symbols' do
+        let(:local_state_digest) { state_digest }
+        let(:local_nonce_digest) { nonce_digest }
+        let(:local_session) {
+          {
+            'oidc' => {
+              'state_digest' => local_state_digest,
+              'nonce_digest' => local_nonce_digest,
+            }
+          }.deep_symbolize_keys
+        }
+
+        subject { described_class.new(client: client, session: local_session) }
+
+        it 'is successfully fetches session values' do
+          expect(subject).to receive(:get_oidc_value_from_session).
+            with(:nonce_digest).and_return(local_nonce_digest)
+
+          expect(subject).to receive(:get_oidc_value_from_session).
+            with(:state_digest).and_return(local_state_digest)
+
+          subject.call(params)
+        end
+      end
+
+      context 'when object keys are strings' do
+        let(:local_state_digest) { state_digest }
+        let(:local_nonce_digest) { nonce_digest }
+        let(:local_session) {
+          {
+            'oidc' => {
+              'state_digest' => local_state_digest,
+              'nonce_digest' => local_nonce_digest,
+            }
+          }
+        }
+
+        subject { described_class.new(client: client, session: local_session) }
+
+        it 'is successfully fetches session values' do
+          expect(subject).to receive(:get_oidc_value_from_session).
+            with(:nonce_digest).and_return(local_nonce_digest)
+
+          expect(subject).to receive(:get_oidc_value_from_session).
+            with(:state_digest).and_return(local_state_digest)
+
+          subject.call(params)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We recently identified an issue where the session object serialization would differ depending on an application's version of Rails and/or session storage. Technically, the values should always be a standard hash with stringed keys, however, some recent partners apps had custom session handling which produced a hash with symbolized keys. This PR normalizes the session object to a hash with symbolized keys. 

- [X] Tested with the Partner Dashboard
- [X] Tested with Touchpoints (@amoose)