### PR TITLE
Remove activesupport from dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .env*
 .ruby_version
-Gemfile.lock
 tmp/
 *.pem
 *.crt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     omniauth_login_dot_gov (0.0.1)
-      activesupport (~> 5.2)
       faraday (~> 0.17)
       json-jwt (~> 1.11)
       jwt (~> 2.2)
@@ -12,29 +11,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     aes_key_wrap (1.0.1)
-    bindata (2.4.4)
+    bindata (2.4.6)
     byebug (10.0.2)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.7)
     hashie (3.5.7)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
     json-jwt (1.11.0)
@@ -43,7 +43,7 @@ GEM
       bindata
     jwt (2.2.1)
     method_source (0.9.2)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
     omniauth (1.8.1)
@@ -56,7 +56,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    rack (2.0.7)
+    rack (2.2.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -77,12 +77,13 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/omniauth_login_dot_gov.gemspec
+++ b/omniauth_login_dot_gov.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'activesupport', '~> 5.2'
   s.add_dependency 'faraday', '~> 0.17'
   s.add_dependency 'json-jwt', '~> 1.11'
   s.add_dependency 'jwt', '~> 2.2'


### PR DESCRIPTION
This gem isn't using activesupport directly, so no reason to prevent
using it with Rails 6

Also removed Gemfile.lock from .gitignore, since it was already added to the repo.