### PR TITLE
allow configuring aal in the omniauth client

### DIFF
--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -33,7 +33,7 @@ module OmniAuth
         if client.aal.nil?
           nil
         elsif VALID_AAL_VALUES.include?(client.aal.to_s)
-          client.aal
+          client.aal.to_s
         else
           raise "Invalid AAL, choose one of #{VALID_AAL_VALUES}"
         end
@@ -48,7 +48,7 @@ module OmniAuth
           'http://idmanagement.gov/ns/assurance/loa/1'
         end
 
-        values << case aal.to_s
+        values << case aal
         when '2'
           'http://idmanagement.gov/ns/assurance/aal/2'
         when '3'

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Authorization
       attr_reader :session, :client
-      VALID_AAL_VALUES = [2, 3, '3-hspd12']
+      VALID_AAL_VALUES = %w[2 3 3-hspd12].freeze
 
       def initialize(session:, client:)
         @session = session

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Authorization
       attr_reader :session, :client
-      VALID_AAL_VALUES = %w[2 3 3-hspd12].freeze
+      VALID_AAL_VALUES = %w[2 2-phishing-resistant 2-hspd12 3 3-hspd12].freeze
 
       def initialize(session:, client:)
         @session = session
@@ -51,6 +51,10 @@ module OmniAuth
         values << case aal
         when '2'
           'http://idmanagement.gov/ns/assurance/aal/2'
+        when '2-hspd12'
+          'http://idmanagement.gov/ns/assurance/aal/2?hspd12=true'
+        when '2-phishing-resistant'
+          'http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true'
         when '3'
           'http://idmanagement.gov/ns/assurance/aal/3'
         when '3-hspd12'

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -2,6 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Authorization
       attr_reader :session, :client
+      VALID_AAL_VALUES = [2, 3, '3-hspd12']
 
       def initialize(session:, client:)
         @session = session
@@ -26,6 +27,16 @@ module OmniAuth
           state: state,
           nonce: nonce,
         }
+      end
+
+      def aal
+        if client.aal.nil?
+          nil
+        elsif VALID_AAL_VALUES.include?(client.aal.to_s)
+          client.aal
+        else
+          raise "Invalid AAL, choose one of #{VALID_AAL_VALUES}"
+        end
       end
 
       def acr_values

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -40,11 +40,24 @@ module OmniAuth
       end
 
       def acr_values
-        if client.ial == 2
+        values = []
+
+        values << if client.ial == 2
           'http://idmanagement.gov/ns/assurance/loa/3'
         else
           'http://idmanagement.gov/ns/assurance/loa/1'
         end
+
+        values << case aal.to_s
+        when '2'
+          'http://idmanagement.gov/ns/assurance/aal/2'
+        when '3'
+          'http://idmanagement.gov/ns/assurance/aal/3'
+        when '3-hspd12'
+          'http://idmanagement.gov/ns/assurance/aal/3?hspd12=true'
+        end
+
+        values.join(' ').strip
       end
 
       def state

--- a/lib/omniauth/login_dot_gov/client.rb
+++ b/lib/omniauth/login_dot_gov/client.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Client
       attr_reader :client_id, :ial, :idp_configuration, :private_key,
-                  :redirect_uri, :scope
+                  :redirect_uri, :scope, :aal
 
       def initialize(
         client_id:,
@@ -10,10 +10,12 @@ module OmniAuth
         idp_base_url:,
         private_key:,
         redirect_uri:,
-        scope:
+        scope:,
+        aal: nil
       )
         @client_id = client_id
         @ial = ial
+        @aal = aal
         @idp_configuration = IdpConfiguration.new(idp_base_url: idp_base_url)
         @private_key = private_key
         @redirect_uri = redirect_uri

--- a/lib/omniauth/strategies/login_dot_gov.rb
+++ b/lib/omniauth/strategies/login_dot_gov.rb
@@ -48,6 +48,7 @@ module OmniAuth
         @client ||= OmniAuth::LoginDotGov::Client.new(
           client_id: options.client_id,
           ial: options.ial,
+          aal: options.aal,
           idp_base_url: options.idp_base_url,
           private_key: options.private_key,
           redirect_uri: options.redirect_uri,

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -1,5 +1,6 @@
 describe OmniAuth::LoginDotGov::Authorization do
-  let(:client) { MockClient.new }
+  let(:aal) { nil }
+  let(:client) { MockClient.new({aal: aal}) }
   let(:session) { {} }
 
   subject { described_class.new(session: session, client: client) }
@@ -30,6 +31,20 @@ describe OmniAuth::LoginDotGov::Authorization do
       expect(params['state']).to_not be_blank
       state_digest = OpenSSL::Digest::SHA256.base64digest(params['state'])
       expect(state_digest).to eq(session[:oidc][:state_digest])
+    end
+
+    context 'Client configured with AAL 3-hspd12' do
+      let(:aal) { '3-hspd12' }
+      it 'returns an auth URL with AAL 3-hspd12' do
+        auth_uri = URI.parse(subject.redirect_url)
+
+        expect(auth_uri.hostname).to eq('idp.example.gov')
+        expect(auth_uri.path).to eq('/openid_connect/authorize')
+
+        params = Rack::Utils.parse_query(auth_uri.query)
+
+        expect(params['aal']).to eq(aal)
+      end
     end
   end
 end

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -1,6 +1,6 @@
 describe OmniAuth::LoginDotGov::Authorization do
   let(:aal) { nil }
-  let(:client) { MockClient.new({aal: aal}) }
+  let(:client) { MockClient.new(aal: aal) }
   let(:session) { {} }
 
   subject { described_class.new(session: session, client: client) }

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -43,7 +43,7 @@ describe OmniAuth::LoginDotGov::Authorization do
 
         params = Rack::Utils.parse_query(auth_uri.query)
 
-        expect(params['aal']).to eq(aal)
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true')
       end
     end
   end

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -33,6 +33,34 @@ describe OmniAuth::LoginDotGov::Authorization do
       expect(state_digest).to eq(session[:oidc][:state_digest])
     end
 
+    context 'Client configured with AAL 2-phishing-resistant' do
+      let(:aal) { '2-phishing-resistant' }
+      it 'returns an auth URL with AAL 2-phishing-resistant' do
+        auth_uri = URI.parse(subject.redirect_url)
+
+        expect(auth_uri.hostname).to eq('idp.example.gov')
+        expect(auth_uri.path).to eq('/openid_connect/authorize')
+
+        params = Rack::Utils.parse_query(auth_uri.query)
+
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true')
+      end
+    end
+
+    context 'Client configured with AAL 2-hspd12' do
+      let(:aal) { '2-hspd12' }
+      it 'returns an auth URL with AAL 2-hspd12' do
+        auth_uri = URI.parse(subject.redirect_url)
+
+        expect(auth_uri.hostname).to eq('idp.example.gov')
+        expect(auth_uri.path).to eq('/openid_connect/authorize')
+
+        params = Rack::Utils.parse_query(auth_uri.query)
+
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/2?hspd12=true')
+      end
+    end
+
     context 'Client configured with AAL 3-hspd12' do
       let(:aal) { '3-hspd12' }
       it 'returns an auth URL with AAL 3-hspd12' do

--- a/spec/support/mock_client.rb
+++ b/spec/support/mock_client.rb
@@ -1,10 +1,11 @@
 class MockClient
   attr_reader :client_id, :ial, :idp_configuration, :private_key,
-              :redirect_uri, :scope
+              :redirect_uri, :scope, :aal
 
   def initialize(overrides = {})
     @client_id = ClientFixtures.client_id
     @ial = 1
+    @aal = nil
     @idp_configuration = MockIdpConfiguration.new
     @private_key = ClientFixtures.private_key
     @redirect_uri = ClientFixtures.redirect_uri


### PR DESCRIPTION
Currently, users of the library are unable to specify AAL in their auth requests which means they must use the default. This PR adds the ability to configure it.