### PR TITLE
allow 10-second leeway when decoding tokens

### DIFF
--- a/lib/omniauth/login_dot_gov/id_token.rb
+++ b/lib/omniauth/login_dot_gov/id_token.rb
@@ -38,7 +38,8 @@ module OmniAuth
           id_token,
           client.idp_configuration.public_key,
           true,
-          algorithm: 'RS256'
+          algorithm: 'RS256',
+          leeway: 10
         ).first
       end
     end

--- a/lib/omniauth/login_dot_gov/version.rb
+++ b/lib/omniauth/login_dot_gov/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LoginDotGov
-    VERSION = '0.1.2'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/spec/omniauth/login_dot_gov/id_token_spec.rb
+++ b/spec/omniauth/login_dot_gov/id_token_spec.rb
@@ -35,5 +35,22 @@ describe OmniAuth::LoginDotGov::IdToken do
         )
       end
     end
+    context 'when the token nbf is within 10 seconds past decoding time' do
+      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 10, nonce: jwt_nonce }, IdpFixtures.private_key, 'RS256') }
+
+      it 'allows 10 seconds of leeway' do
+        expect(subject.verify_nonce(session_nonce_digest)).to eq true
+      end
+    end
+
+    context 'when the token nbf is not within 10 seconds past decoding time' do
+      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 11, nonce: jwt_nonce }, IdpFixtures.private_key, 'RS256') }
+
+      it 'raises ImmatureSignature error' do
+        expect { subject.verify_nonce(session_nonce_digest) }.to raise_error(
+          JWT::ImmatureSignature
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/18F/omniauth_login_dot_gov/issues/26

Note: The `leeway` option sets a global leeway, which is used for both the [not before](https://github.com/jwt/ruby-jwt#not-before-time-claim) and [expiration](https://github.com/jwt/ruby-jwt#expiration-time-claim) values:
https://github.com/jwt/ruby-jwt/blob/5818f9868ae201f123b2522679bf8af139bbba13/lib/jwt/verify.rb#L101

Those options can be passed individually, but the global leeway seemed like the simplest and most flexible solution.