### PR TITLE
Update IAL values to remove usage of LOA values in favor of the correct IAL values

### DIFF
--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -39,13 +39,25 @@ module OmniAuth
         end
       end
 
+      def ial
+        case client.ial
+        when '1', 1
+          1
+        when '2', 2
+          2
+        else
+          raise "Invalid IAL, choose 1 or 2"
+        end
+      end
+
       def acr_values
         values = []
 
-        values << if client.ial == 2
-          'http://idmanagement.gov/ns/assurance/loa/3'
-        else
-          'http://idmanagement.gov/ns/assurance/loa/1'
+        values << case ial
+        when 1
+          'http://idmanagement.gov/ns/assurance/ial/1'
+        when 2
+          'http://idmanagement.gov/ns/assurance/ial/2'
         end
 
         values << case aal

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -1,6 +1,7 @@
 describe OmniAuth::LoginDotGov::Authorization do
   let(:aal) { nil }
-  let(:client) { MockClient.new(aal: aal) }
+  let(:ial) { 1 }
+  let(:client) { MockClient.new(aal: aal, ial: ial) }
   let(:session) { {} }
 
   subject { described_class.new(session: session, client: client) }
@@ -14,7 +15,7 @@ describe OmniAuth::LoginDotGov::Authorization do
 
       params = Rack::Utils.parse_query(auth_uri.query)
 
-      expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1')
+      expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/ial/1')
       expect(params['client_id']).to eq('urn:gov:gsa:openidconnect:sp:omniauth-test-client')
       expect(params['response_type']).to eq('code')
       expect(params['redirect_uri']).to eq('http://omniauth.example.gov/auth/LoginDotGov/callback')
@@ -43,7 +44,7 @@ describe OmniAuth::LoginDotGov::Authorization do
 
         params = Rack::Utils.parse_query(auth_uri.query)
 
-        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true')
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/2?phishing_resistant=true')
       end
     end
 
@@ -57,7 +58,7 @@ describe OmniAuth::LoginDotGov::Authorization do
 
         params = Rack::Utils.parse_query(auth_uri.query)
 
-        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/2?hspd12=true')
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/2?hspd12=true')
       end
     end
 
@@ -71,7 +72,22 @@ describe OmniAuth::LoginDotGov::Authorization do
 
         params = Rack::Utils.parse_query(auth_uri.query)
 
-        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/loa/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true')
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true')
+      end
+    end
+
+    context 'Client configured with IAL 2' do
+      let(:ial) { '2' }
+      let(:aal) { '2' }
+      it 'returns an auth URL with IAL 2' do
+        auth_uri = URI.parse(subject.redirect_url)
+
+        expect(auth_uri.hostname).to eq('idp.example.gov')
+        expect(auth_uri.path).to eq('/openid_connect/authorize')
+
+        params = Rack::Utils.parse_query(auth_uri.query)
+
+        expect(params['acr_values']).to eq('http://idmanagement.gov/ns/assurance/ial/2 http://idmanagement.gov/ns/assurance/aal/2')
       end
     end
   end


### PR DESCRIPTION
We moved away from LOA values to IAL a while ago, and while both are supported, we should use the most recent ones here