### PR TITLE
If requested in scope, all_emails should be available in the userinfo_from_response

### DIFF
--- a/lib/omniauth/login_dot_gov/userinfo.rb
+++ b/lib/omniauth/login_dot_gov/userinfo.rb
@@ -4,6 +4,7 @@ module OmniAuth
       :uuid,
       :email,
       :email_verified,
+      :all_emails,
       :family_name,
       :given_name,
       :birthdate,
@@ -12,11 +13,11 @@ module OmniAuth
       :phone,
       :phone_verified
     ) do
-
       def initialize(
         uuid: nil,
         email: nil,
         email_verified: nil,
+        all_emails: nil,
         family_name: nil,
         given_name: nil,
         birthdate: nil,
@@ -28,6 +29,7 @@ module OmniAuth
         self.uuid = uuid
         self.email = email
         self.email_verified = email_verified
+        self.all_emails = all_emails
         self.family_name = family_name
         self.given_name = given_name
         self.birthdate = birthdate

--- a/lib/omniauth/login_dot_gov/userinfo_request.rb
+++ b/lib/omniauth/login_dot_gov/userinfo_request.rb
@@ -26,6 +26,7 @@ module OmniAuth
           uuid: parsed_body['sub'],
           email: parsed_body['email'],
           email_verified: parsed_body['email_verified'],
+          all_emails: parsed_body['all_emails'],
           family_name: parsed_body['family_name'],
           given_name: parsed_body['given_name'],
           birthdate: parsed_body['birthdate'],

--- a/lib/omniauth/login_dot_gov/version.rb
+++ b/lib/omniauth/login_dot_gov/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LoginDotGov
-    VERSION = '2.0.1'.freeze
+    VERSION = '2.0.2'.freeze
   end
 end

--- a/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
+++ b/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
@@ -35,6 +35,24 @@ describe OmniAuth::LoginDotGov::UserinfoRequest do
         expect(userinfo.uuid).to eq(uuid)
         expect(userinfo.email).to eq(email)
         expect(userinfo.email_verified).to eq(email_verified)
+        expect(userinfo.all_emails).to be_nil
+      end
+
+      context 'returns userinfo with all_emails' do
+        let(:all_emails) { [email, 'qwerty@gmail.com'] }
+        let(:response_body) do
+          {
+            sub: uuid,
+            email: email,
+            email_verified: email_verified,
+            all_emails: all_emails,
+          }.to_json
+        end
+
+        it 'returns all_emails' do
+          userinfo = subject.request_userinfo
+          expect(userinfo.all_emails).to eq(all_emails)
+        end
       end
     end
 


### PR DESCRIPTION
If `all_emails` is requested in the scope, this PR includes it as part of the userinfo response stored for the callback.  If it was not a part of the scope, all_emails will be nil.

The reason for the request is that we would like to have the user's other emails available in the [MD FAMLI](https://paidleave.maryland.gov/Pages/default.aspx) using this gem.  In reviewing the [developers.login.gov docs for user-info](https://developers.login.gov/oidc/user-info/), the example response looks like it should be returned.