### PR TITLE
Include verification timestamp in userinfo when requested in scope

### DIFF
--- a/lib/omniauth/login_dot_gov/userinfo.rb
+++ b/lib/omniauth/login_dot_gov/userinfo.rb
@@ -11,7 +11,8 @@ module OmniAuth
       :social_security_number,
       :address,
       :phone,
-      :phone_verified
+      :phone_verified,
+      :verified_at
     ) do
       def initialize(
         uuid: nil,
@@ -24,7 +25,8 @@ module OmniAuth
         social_security_number: nil,
         address: nil,
         phone: nil,
-        phone_verified: nil
+        phone_verified: nil,
+        verified_at: nil
       )
         self.uuid = uuid
         self.email = email
@@ -37,6 +39,7 @@ module OmniAuth
         self.address = address
         self.phone = phone
         self.phone_verified = phone_verified
+        self.verified_at = verified_at
       end
 
       def to_h

--- a/lib/omniauth/login_dot_gov/userinfo_request.rb
+++ b/lib/omniauth/login_dot_gov/userinfo_request.rb
@@ -33,7 +33,8 @@ module OmniAuth
           social_security_number: parsed_body['social_security_number'],
           address: parsed_body['address'],
           phone: parsed_body['phone'],
-          phone_verified: parsed_body['phone_verified']
+          phone_verified: parsed_body['phone_verified'],
+          verified_at: parsed_body['verified_at'],
         )
       end
 

--- a/lib/omniauth/login_dot_gov/userinfo_request.rb
+++ b/lib/omniauth/login_dot_gov/userinfo_request.rb
@@ -34,7 +34,7 @@ module OmniAuth
           address: parsed_body['address'],
           phone: parsed_body['phone'],
           phone_verified: parsed_body['phone_verified'],
-          verified_at: parsed_body['verified_at'],
+          verified_at: parsed_body['verified_at'] && Time.at(parsed_body['verified_at'].to_i)
         )
       end
 

--- a/lib/omniauth/login_dot_gov/version.rb
+++ b/lib/omniauth/login_dot_gov/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LoginDotGov
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.2.0'.freeze
   end
 end

--- a/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
+++ b/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
@@ -67,9 +67,9 @@ describe OmniAuth::LoginDotGov::UserinfoRequest do
           }.to_json
         end
 
-        it 'returns all_emails' do
+        it 'returns verified_at' do
           userinfo = subject.request_userinfo
-          expect(userinfo.verified_at).to eq(verified_at)
+          expect(userinfo.verified_at).to eq(Time.at(1723054856))
         end
       end
 

--- a/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
+++ b/spec/omniauth/login_dot_gov/userinfo_request_spec.rb
@@ -36,6 +36,7 @@ describe OmniAuth::LoginDotGov::UserinfoRequest do
         expect(userinfo.email).to eq(email)
         expect(userinfo.email_verified).to eq(email_verified)
         expect(userinfo.all_emails).to be_nil
+        expect(userinfo.verified_at).to be_nil
       end
 
       context 'returns userinfo with all_emails' do
@@ -54,22 +55,39 @@ describe OmniAuth::LoginDotGov::UserinfoRequest do
           expect(userinfo.all_emails).to eq(all_emails)
         end
       end
-    end
 
-    context 'when the request fails' do
-      before do
-        stub_userinfo_request(
-          body: 'Access Denied',
-          status: 403,
-          access_token: access_token
-        )
+      context 'returns userinfo with verified_at timestamp' do
+        let(:verified_at) { 1723054856 }
+        let(:response_body) do
+          {
+            sub: uuid,
+            email: email,
+            email_verified: email_verified,
+            verified_at: verified_at
+          }.to_json
+        end
+
+        it 'returns all_emails' do
+          userinfo = subject.request_userinfo
+          expect(userinfo.verified_at).to eq(verified_at)
+        end
       end
 
-      it 'raises an error' do
-        expect { subject.request_userinfo }.to raise_error(
-          OmniAuth::LoginDotGov::UserinfoRequestError,
-          'Userinfo request failed with status code: 403'
-        )
+      context 'when the request fails' do
+        before do
+          stub_userinfo_request(
+            body: 'Access Denied',
+            status: 403,
+            access_token: access_token
+          )
+        end
+
+        it 'raises an error' do
+          expect { subject.request_userinfo }.to raise_error(
+            OmniAuth::LoginDotGov::UserinfoRequestError,
+            'Userinfo request failed with status code: 403'
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Returns the identity verification timestamp when requested in scope (`profile:verified_at`).

We are currently using this to determine whether users have already been verified during their initial login.