### PR TITLE
Support reading and verifying with multiple IdP public keys

### DIFF
--- a/lib/omniauth/login_dot_gov/id_token.rb
+++ b/lib/omniauth/login_dot_gov/id_token.rb
@@ -36,7 +36,7 @@ module OmniAuth
       def decoded_id_token
         @decoded_id_token ||= JWT.decode(
           id_token,
-          client.idp_configuration.public_key,
+          client.idp_configuration.public_keys,
           true,
           algorithm: 'RS256',
           leeway: 10

--- a/lib/omniauth/login_dot_gov/idp_configuration.rb
+++ b/lib/omniauth/login_dot_gov/idp_configuration.rb
@@ -21,10 +21,12 @@ module OmniAuth
         openid_configuration['end_session_endpoint']
       end
 
-      def public_key
-        @public_key = begin
-          certs = JSON.parse(jwks_endpoint_response.body)
-          JSON::JWK.new(certs['keys'].first).to_key
+      def public_keys
+        @public_keys = begin
+          keys = JSON.parse(jwks_endpoint_response.body)['keys']
+          keys.map do |key|
+            JSON::JWK.new(key).to_key
+          end
         end
       end
 

--- a/lib/omniauth/login_dot_gov/version.rb
+++ b/lib/omniauth/login_dot_gov/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LoginDotGov
-    VERSION = '2.2.0'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end

--- a/spec/omniauth/login_dot_gov/callback_spec.rb
+++ b/spec/omniauth/login_dot_gov/callback_spec.rb
@@ -33,7 +33,7 @@ describe OmniAuth::LoginDotGov::Callback do
   let(:id_token_jwt) do
     JWT.encode(
       { nonce: nonce },
-      IdpFixtures.private_key,
+      IdpFixtures.private_keys.first,
       'RS256'
     )
   end

--- a/spec/omniauth/login_dot_gov/id_token_request_spec.rb
+++ b/spec/omniauth/login_dot_gov/id_token_request_spec.rb
@@ -7,7 +7,7 @@ describe OmniAuth::LoginDotGov::IdTokenRequest do
   # Response values
   let(:access_token) { 'access-token-1234' }
   let(:id_token_jwt) do
-    JWT.encode({ asdf: 1234 }, IdpFixtures.private_key, 'RS256')
+    JWT.encode({ asdf: 1234 }, IdpFixtures.private_keys.first, 'RS256')
   end
   let(:token_response_body) do
     {

--- a/spec/omniauth/login_dot_gov/id_token_spec.rb
+++ b/spec/omniauth/login_dot_gov/id_token_spec.rb
@@ -6,7 +6,7 @@ describe OmniAuth::LoginDotGov::IdToken do
 
   let(:jwt_nonce) { session_nonce }
   let(:jwt) do
-    JWT.encode({ nonce: jwt_nonce }, IdpFixtures.private_key, 'RS256')
+    JWT.encode({ nonce: jwt_nonce }, IdpFixtures.private_keys.first, 'RS256')
   end
 
   subject do
@@ -35,8 +35,29 @@ describe OmniAuth::LoginDotGov::IdToken do
         )
       end
     end
+
+    context 'when the key is signed by any of the private_keys' do
+      it 'returns true' do
+        aggregate_failures do
+          IdpFixtures.private_keys.each do |private_key|
+            jwt = JWT.encode({ nonce: jwt_nonce }, private_key, 'RS256')
+            expect(subject.verify_nonce(session_nonce_digest)).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'when the key is signed by an invalid private_key' do
+      let(:jwt) { JWT.encode({ nonce: jwt_nonce }, OpenSSL::PKey::RSA.new(2048), 'RS256') }
+      it 'raises VerificationError' do
+        expect do
+          subject.verify_nonce(session_nonce_digest)
+        end.to raise_error(JWT::VerificationError)
+      end
+    end
+
     context 'when the token nbf is within 10 seconds past decoding time' do
-      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 10, nonce: jwt_nonce }, IdpFixtures.private_key, 'RS256') }
+      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 10, nonce: jwt_nonce }, IdpFixtures.private_keys.first, 'RS256') }
 
       it 'allows 10 seconds of leeway' do
         expect(subject.verify_nonce(session_nonce_digest)).to eq true
@@ -44,7 +65,7 @@ describe OmniAuth::LoginDotGov::IdToken do
     end
 
     context 'when the token nbf is not within 10 seconds past decoding time' do
-      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 11, nonce: jwt_nonce }, IdpFixtures.private_key, 'RS256') }
+      let(:jwt) { JWT.encode({ nbf: Time.now.to_i + 11, nonce: jwt_nonce }, IdpFixtures.private_keys.first, 'RS256') }
 
       it 'raises ImmatureSignature error' do
         expect { subject.verify_nonce(session_nonce_digest) }.to raise_error(

--- a/spec/omniauth/login_dot_gov/idp_configuration_spec.rb
+++ b/spec/omniauth/login_dot_gov/idp_configuration_spec.rb
@@ -36,16 +36,16 @@ describe OmniAuth::LoginDotGov::IdpConfiguration do
     end
   end
 
-  describe '#public_key' do
+  describe '#public_keys' do
     before { stub_openid_configuration_request }
 
     context 'when the certs request is successful' do
       before { stub_jwks_request }
 
-      it 'returns the IDP public key' do
-        result = subject.public_key
+      it 'returns the IDP public keys' do
+        result = subject.public_keys
 
-        expect(result.to_pem).to eq(IdpFixtures.public_key.to_pem)
+        expect(result.map(&:to_pem)).to eq(IdpFixtures.public_keys.map(&:to_pem))
       end
     end
 
@@ -53,7 +53,7 @@ describe OmniAuth::LoginDotGov::IdpConfiguration do
       before { stub_jwks_request(body: 'Not found', status: 404) }
 
       it 'raises an error' do
-        expect { subject.public_key }.to raise_error(
+        expect { subject.public_keys }.to raise_error(
           OmniAuth::LoginDotGov::OpenidDiscoveryError,
           'JWKS request failed with status code: 404'
         )

--- a/spec/support/fixtures/idp_fixtures.rb
+++ b/spec/support/fixtures/idp_fixtures.rb
@@ -1,14 +1,18 @@
 module IdpFixtures
-  def self.private_key
-    @private_key ||= OpenSSL::PKey::RSA.new(2048)
+  def self.private_keys
+    @private_keys ||= [OpenSSL::PKey::RSA.new(2048), OpenSSL::PKey::RSA.new(2048)]
   end
 
-  def self.public_key
-    @public_key ||= private_key.public_key
+  def self.public_keys
+    @public_keys ||= private_keys.map do |private_key|
+      private_key.public_key
+    end
   end
 
-  def self.public_key_jwk
-    JSON::JWK.new(public_key)
+  def self.public_key_jwks
+    public_keys.map do |public_key|
+      JSON::JWK.new(public_key)
+    end
   end
 
   def self.base_url

--- a/spec/support/idp_webmocks/jwks_webmock.rb
+++ b/spec/support/idp_webmocks/jwks_webmock.rb
@@ -5,10 +5,10 @@ module JwksWebmock
   end
 
   def default_jwks_response_body
-    jwks_response_body(key: IdpFixtures.public_key_jwk)
+    jwks_response_body(keys: IdpFixtures.public_key_jwks)
   end
 
-  def jwks_response_body(key:)
-    { keys: [key] }.to_json
+  def jwks_response_body(keys:)
+    { keys: keys }.to_json
   end
 end

--- a/spec/support/mock_idp_configuration.rb
+++ b/spec/support/mock_idp_configuration.rb
@@ -19,7 +19,7 @@ class MockIdpConfiguration
     IdpFixtures.jwks_uri
   end
 
-  def public_key
-    IdpFixtures.public_key
+  def public_keys
+    IdpFixtures.public_keys
   end
 end


### PR DESCRIPTION
To go along with https://github.com/18F/identity-idp/pull/11626, this PR adds support in the gem for handling multiple OIDC keys for zero-downtime IdP key rotations