### PR TITLE
Bump jwt dependency to ~> 3.2

### DIFF
--- a/omniauth_login_dot_gov.gemspec
+++ b/omniauth_login_dot_gov.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 2.0'
   s.add_dependency 'json-jwt', '~> 1.11'
-  s.add_dependency 'jwt', '~> 2.2'
+  s.add_dependency 'jwt', '~> 3.2'
   s.add_dependency 'multi_json', '~> 1.14'
   s.add_dependency 'omniauth', '~> 2.0'
 


### PR DESCRIPTION
This allows apps which use omniauth_login_dot_gov to update to the latest version of jwt and stay up-to-date with all the latest and greatest (including security fixes).

Closes #39

Testing:

- [x] tests pass locally (`bundle exec rspec`) (Note: #44 is also required to get passing tests)
- [x] when our app uses this branch, login seems to work fine