### PR TITLE
gitignore simplecov coverage directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 Gemfile.lock
 tmp/
 tmp/*
+coverage/


### PR DESCRIPTION
I tried running the test suite with `COVERAGE=1 bundle exec rspec` and that created a coverage/ directory which I had to carefully avoid committing. That seems like something that can be gitignored instead.