### PR TITLE
Ensure tests can run

### DIFF
--- a/spec/support/cgi.rb
+++ b/spec/support/cgi.rb
@@ -1,0 +1,1 @@
+require 'cgi'


### PR DESCRIPTION
I observed that when I run the tests locally, I see errors like this:

```
NoMethodError:
       undefined method 'parse' for class CGI
```

There are a few specs which depend on `CGI.parse` but we never actually require the cgi gem anywhere in this codebase. In the past, everything Just Worked because one of our direct dependencies did require it, so it was loaded by the time we got here. But now, on a freshly-regenerated `Gemfile.lock`, it is no longer auto-required by one of our direct dependencies.

No worries, we can load it ourselves.