### PR TITLE
Update omniauth to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ This gem is an Omniauth strategy to provide authentication with Login.gov in a r
 #### ⚠️  Common Vulnerabilities and Exposure Warning:
 There is a known vulnerability with Omniauth that affects this gem as
 well as any implementation of Omniauth with a single strategy. Please
-review [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284) for more
-information and mitigation steps. The [Omniauth Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) also
-has relevant information (August 2019).
+review the
+[Omniauth Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)
+for more information and mitigation steps.
+[CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284) also
+has relevant information (February 2025).
 
 The vulnerability allows for an attacker to connect an authentication provider (like Login.gov) to a client application without any user interaction. The vulnerability is partially mitigated for this gem because Login.gov requires users to explicitly authorize an application on Login.gov before an application is connected. Users of this gem should still understand the vulnerability and mitigate further with the steps detailed in the Omniauth wiki above.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ This gem is an Omniauth strategy to provide authentication with Login.gov in a r
 
 #### ⚠️  Common Vulnerabilities and Exposure Warning:
 There is a known vulnerability with Omniauth that affects this gem as
-well as any implementation of Omniauth with a single strategy. Please
-review the
+well as any implementation of Omniauth with a single strategy.
+
+> A key part of resolving this vulnerability is refusing GET requests to /auth/:provider endpoints.
+
+Please review the
 [Omniauth Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)
 for more information and mitigation steps.
 [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284) also

--- a/omniauth_login_dot_gov.gemspec
+++ b/omniauth_login_dot_gov.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json-jwt', '~> 1.11'
   s.add_dependency 'jwt', '~> 3.2'
   s.add_dependency 'multi_json', '~> 1.14'
-  s.add_dependency 'omniauth', '~> 2.0'
+  s.add_dependency 'omniauth', '~> 2.1'
 
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
This updates the `omniauth` gem dependency to 2.1, which is currently 2.1.4. 

I'd appreciate confirmation that we can remove the CVE warning in the README.md. It appears to have been fixed in v2.0.0, which was changed in this repo in October 2021.  
In that case, I'll add a commit with that change.