### PR TITLE
Add locale option

### DIFF
--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -105,8 +105,6 @@ module OmniAuth
 
         request_locale
       end
-
-
     end
   end
 end

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -2,6 +2,8 @@ module OmniAuth
   module LoginDotGov
     class Authorization
       attr_reader :session, :client
+
+      SUPPORTED_LOCALES = %w[en es fr].freeze
       VALID_AAL_VALUES = %w[2 2-phishing-resistant 2-hspd12 3 3-hspd12].freeze
 
       def initialize(session:, client:)
@@ -25,8 +27,8 @@ module OmniAuth
           redirect_uri: client.redirect_uri,
           scope: client.scope,
           state: state,
-          locale: client.locale,
-          nonce: nonce,
+          locale: locale,
+          nonce: nonce
         }
       end
 
@@ -96,6 +98,15 @@ module OmniAuth
           state_value
         end
       end
+
+      def locale
+        request_locale = client.locale
+        return unless request_locale.present? && SUPPORTED_LOCALES.include?(request_locale)
+
+        request_locale
+      end
+
+
     end
   end
 end

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -3,7 +3,7 @@ module OmniAuth
     class Authorization
       attr_reader :session, :client
 
-      SUPPORTED_LOCALES = %w[en es fr].freeze
+      SUPPORTED_LOCALES = %w[en es fr zh].freeze
       VALID_AAL_VALUES = %w[2 2-phishing-resistant 2-hspd12 3 3-hspd12].freeze
 
       def initialize(session:, client:)

--- a/lib/omniauth/login_dot_gov/authorization.rb
+++ b/lib/omniauth/login_dot_gov/authorization.rb
@@ -25,6 +25,7 @@ module OmniAuth
           redirect_uri: client.redirect_uri,
           scope: client.scope,
           state: state,
+          locale: client.locale,
           nonce: nonce,
         }
       end

--- a/lib/omniauth/login_dot_gov/client.rb
+++ b/lib/omniauth/login_dot_gov/client.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Client
       attr_reader :client_id, :ial, :idp_configuration, :private_key,
-                  :redirect_uri, :scope, :aal
+                  :redirect_uri, :scope, :aal, :locale
 
       def initialize(
         client_id:,
@@ -11,6 +11,7 @@ module OmniAuth
         private_key:,
         redirect_uri:,
         scope:,
+        locale:,
         aal: nil
       )
         @client_id = client_id
@@ -19,6 +20,7 @@ module OmniAuth
         @idp_configuration = IdpConfiguration.new(idp_base_url: idp_base_url)
         @private_key = private_key
         @redirect_uri = redirect_uri
+        @locale = locale
         @scope = scope
       end
     end

--- a/lib/omniauth/login_dot_gov/client.rb
+++ b/lib/omniauth/login_dot_gov/client.rb
@@ -11,7 +11,7 @@ module OmniAuth
         private_key:,
         redirect_uri:,
         scope:,
-        locale:,
+        locale: 'en',
         aal: nil
       )
         @client_id = client_id

--- a/lib/omniauth/login_dot_gov/client.rb
+++ b/lib/omniauth/login_dot_gov/client.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module LoginDotGov
     class Client
       attr_reader :client_id, :ial, :idp_configuration, :private_key,
-                  :redirect_uri, :scope, :aal, :locale
+                  :redirect_uri, :scope, :locale, :aal
 
       def initialize(
         client_id:,

--- a/lib/omniauth/strategies/login_dot_gov.rb
+++ b/lib/omniauth/strategies/login_dot_gov.rb
@@ -57,6 +57,7 @@ module OmniAuth
           locale: request.params['locale'] || options.locale
         )
       end
+
     end
   end
 end

--- a/lib/omniauth/strategies/login_dot_gov.rb
+++ b/lib/omniauth/strategies/login_dot_gov.rb
@@ -9,6 +9,7 @@ module OmniAuth
       option :private_key
       option :redirect_uri
       option :scope, 'openid email'
+      option :locale, 'en'
 
       attr_reader :authorization, :callback
 
@@ -52,7 +53,8 @@ module OmniAuth
           idp_base_url: options.idp_base_url,
           private_key: options.private_key,
           redirect_uri: options.redirect_uri,
-          scope: options.scope
+          scope: options.scope,
+          locale: request.params['locale'] || options.locale
         )
       end
     end

--- a/lib/omniauth/strategies/login_dot_gov.rb
+++ b/lib/omniauth/strategies/login_dot_gov.rb
@@ -57,7 +57,6 @@ module OmniAuth
           locale: request.params['locale'] || options.locale
         )
       end
-
     end
   end
 end

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -25,9 +25,7 @@ describe OmniAuth::LoginDotGov::Authorization do
       scope = params['scope'].split(' ')
       expect(scope).to include('openid')
       expect(scope).to include('email')
-
-      expect(params['nonce']).to_not be_blank
-      expect(params['nonce'].length).to eq(32)
+      expect(params['nonce']&.length).to eq(32)
       nonce_digest = OpenSSL::Digest::SHA256.base64digest(params['nonce'])
       expect(nonce_digest).to eq(session[:oidc][:nonce_digest])
 

--- a/spec/omniauth/login_dot_gov/authorization_spec.rb
+++ b/spec/omniauth/login_dot_gov/authorization_spec.rb
@@ -1,7 +1,8 @@
 describe OmniAuth::LoginDotGov::Authorization do
   let(:aal) { nil }
   let(:ial) { 1 }
-  let(:client) { MockClient.new(aal: aal, ial: ial) }
+  let(:locale) { 'es' }
+  let(:client) { MockClient.new(aal: aal, ial: ial, locale: locale) }
   let(:session) { {} }
 
   subject { described_class.new(session: session, client: client) }
@@ -19,6 +20,7 @@ describe OmniAuth::LoginDotGov::Authorization do
       expect(params['client_id']).to eq('urn:gov:gsa:openidconnect:sp:omniauth-test-client')
       expect(params['response_type']).to eq('code')
       expect(params['redirect_uri']).to eq('http://omniauth.example.gov/auth/LoginDotGov/callback')
+      expect(params['locale']).to eq('es')
 
       scope = params['scope'].split(' ')
       expect(scope).to include('openid')

--- a/spec/omniauth/login_dot_gov/client_spec.rb
+++ b/spec/omniauth/login_dot_gov/client_spec.rb
@@ -11,7 +11,8 @@ describe OmniAuth::LoginDotGov::Client do
       idp_base_url: IdpFixtures.base_url,
       private_key: ClientFixtures.private_key,
       redirect_uri: ClientFixtures.redirect_uri,
-      scope: 'email openid'
+      scope: 'email openid',
+      locale: 'es'
     )
 
     expect(subject.client_id).to eq(ClientFixtures.client_id)
@@ -20,5 +21,6 @@ describe OmniAuth::LoginDotGov::Client do
     expect(subject.private_key).to eq(ClientFixtures.private_key)
     expect(subject.redirect_uri).to eq(ClientFixtures.redirect_uri)
     expect(subject.scope).to eq('email openid')
+    expect(subject.locale).to eq('es')
   end
 end

--- a/spec/omniauth/login_dot_gov/client_spec.rb
+++ b/spec/omniauth/login_dot_gov/client_spec.rb
@@ -1,5 +1,27 @@
 describe OmniAuth::LoginDotGov::Client do
-  it 'initializes' do
+  it 'initializes without locale' do
+    idp_configuration = MockIdpConfiguration.new
+    allow(OmniAuth::LoginDotGov::IdpConfiguration).to receive(:new).
+      with(idp_base_url: IdpFixtures.base_url).
+      and_return(idp_configuration)
+
+    subject = described_class.new(
+      client_id: ClientFixtures.client_id,
+      ial: 1,
+      idp_base_url: IdpFixtures.base_url,
+      private_key: ClientFixtures.private_key,
+      redirect_uri: ClientFixtures.redirect_uri,
+      scope: 'email openid'
+    )
+    expect(subject.client_id).to eq(ClientFixtures.client_id)
+    expect(subject.ial).to eq(1)
+    expect(subject.idp_configuration).to eq(idp_configuration)
+    expect(subject.private_key).to eq(ClientFixtures.private_key)
+    expect(subject.redirect_uri).to eq(ClientFixtures.redirect_uri)
+    expect(subject.scope).to eq('email openid')
+  end
+
+  it 'initializes with locale' do
     idp_configuration = MockIdpConfiguration.new
     allow(OmniAuth::LoginDotGov::IdpConfiguration).to receive(:new).
       with(idp_base_url: IdpFixtures.base_url).
@@ -14,13 +36,6 @@ describe OmniAuth::LoginDotGov::Client do
       scope: 'email openid',
       locale: 'es'
     )
-
-    expect(subject.client_id).to eq(ClientFixtures.client_id)
-    expect(subject.ial).to eq(1)
-    expect(subject.idp_configuration).to eq(idp_configuration)
-    expect(subject.private_key).to eq(ClientFixtures.private_key)
-    expect(subject.redirect_uri).to eq(ClientFixtures.redirect_uri)
-    expect(subject.scope).to eq('email openid')
     expect(subject.locale).to eq('es')
   end
 end

--- a/spec/support/mock_client.rb
+++ b/spec/support/mock_client.rb
@@ -1,6 +1,6 @@
 class MockClient
   attr_reader :client_id, :ial, :idp_configuration, :private_key,
-              :redirect_uri, :scope, :aal
+              :redirect_uri, :scope, :aal, :locale
 
   def initialize(overrides = {})
     @client_id = ClientFixtures.client_id
@@ -10,6 +10,7 @@ class MockClient
     @private_key = ClientFixtures.private_key
     @redirect_uri = ClientFixtures.redirect_uri
     @scope = 'email openid'
+    @locale = 'en'
 
     overrides.each do |key, value|
       instance_variable_set("@#{key}", value)

--- a/spec/support/mock_client.rb
+++ b/spec/support/mock_client.rb
@@ -1,6 +1,6 @@
 class MockClient
   attr_reader :client_id, :ial, :idp_configuration, :private_key,
-              :redirect_uri, :scope, :aal, :locale
+              :redirect_uri, :scope, :locale, :aal
 
   def initialize(overrides = {})
     @client_id = ClientFixtures.client_id


### PR DESCRIPTION
This adds the ability to specify a locale when submitting a request. 
It is passed via the request params and checked for validity per the options of locale allowed by Login.gov